### PR TITLE
IPv6 TCP checksum calculation

### DIFF
--- a/src/pkt.erl
+++ b/src/pkt.erl
@@ -500,7 +500,7 @@ foldWithOverflow16(A) ->
 			E + 1; % overflow
 		false ->
 			E
-         end.	        
+         end.
 
 makesum(Hdr) ->
 	(checksum(Hdr) bxor 16#FFFF) band 16#FFFF. % bitwise-complement


### PR DESCRIPTION
I have added IPv6 TCP checksum calculation. 
Not sure, if the patch "ommitted variable 'F'" does any merge conflicts. That patch is actually already included by msantos/pkt/master.
