### PR TITLE
IGMPv3 type 0x22 support

### DIFF
--- a/include/pkt_igmp.hrl
+++ b/include/pkt_igmp.hrl
@@ -4,3 +4,11 @@
         csum = 0,
         group
     }).
+
+
+-record(igmp_group, {
+  type = 0,
+  addr,
+  sources = [],
+  aux = <<>>
+  }).

--- a/test/pkt_igmp_tests.erl
+++ b/test/pkt_igmp_tests.erl
@@ -6,7 +6,9 @@
 codec_test_() ->
     [
         decode(),
-        encode()
+        encode(),
+        decode_igmpv3_22(),
+        encode_igmpv3_22()
     ].
 
 packet() ->
@@ -22,5 +24,21 @@ decode() ->
 
 encode() ->
     Packet = packet(),
+    {Header, Payload} = pkt:igmp(Packet),
+    ?_assertEqual(Packet, <<(pkt:igmp(Header))/binary, Payload/binary>>).
+
+
+packet_igmp_22() ->
+    <<16#22, 0, 235,252, 0,0,0,1, 3,0,0,0,239,0,0,1>>.
+
+decode_igmpv3_22() ->
+    {Header, Payload} = pkt:igmp(packet_igmp_22()),
+    ?_assertEqual({
+        #igmp{type = 34, code = 0, csum = 60412, group = [#igmp_group{type = 3, addr = {239,0,0,1}} ]},
+        <<>>
+    }, {Header, Payload}).
+
+encode_igmpv3_22() ->
+    Packet = packet_igmp_22(),
     {Header, Payload} = pkt:igmp(Packet),
     ?_assertEqual(Packet, <<(pkt:igmp(Header))/binary, Payload/binary>>).


### PR DESCRIPTION
I've took schema from http://tools.ietf.org/html/rfc3376#section-4.2

and changed IGMP reader a bit to support IGMPv3  type 0x22 message.
