### PR TITLE
Add decoding of 802.1q header

### DIFF
--- a/src/pkt.erl
+++ b/src/pkt.erl
@@ -219,6 +219,7 @@ decode_next({Proto, Data}, Headers) when
     Proto =:= ipv6;
     Proto =:= linux_cooked;
     Proto =:= null;
+    Proto =:= '802.1q';
 
     Proto =:= ipv6_ah;
     Proto =:= ipv6_dstopts;


### PR DESCRIPTION
When using pkt:decode/1,2 802.1q header is not decoded - an exception is raised:

`
(<0.47.0>) call pkt:decode_next({'802.1q',<<3,86,8,0,69,0,0,200,187,111,0,0,63,132,224,120,192,168,19,5,10,
            219,0,66,19,191,19,191,136,106,129,97,164,12,232,180,0,3,0,168,
            163,252,230,215,0,1,3,16,0,0,0,3,1,0,1,1,0,0,0,152,2,0,0,8,0,0,0,
            5,0,6,0,8,0,0,0,0,2,16,0,117,0,0,6,2,0,0,10,148,3,2,0,9,9,129,3,
            14,24,11,18,6,0,17,4,132,6,1,0,145,0,10,18,8,0,18,4,50,41,0,0,0,
            72,98,70,72,4,12,64,0,119,107,30,40,28,6,7,0,17,134,5,1,1,1,160,
            17,96,15,128,2,7,128,161,9,6,7,4,0,0,1,0,5,3,108,30,161,28,2,1,0,
            2,1,22,48,20,128,7,145,132,150,1,48,48,243,131,1,0,134,6,145,50,
            41,0,0,0,0,0,0,0,19,0,8,0,0,4,157>>},[{ether,<<24,102,218,133,246,153>>,<<0,4,109,231,144,0>>,33024,0}]) ({pkt, decode, 2})
(<0.47.0>) exception_from {pkt,decode_next,2} {error,function_clause}
`

