### PR TITLE
add ?IPV6_PROTO_TCP and ?IPV4_PROTO_TCP macros instead of IPPROTO_TCP

### DIFF
--- a/include/pkt_ipv4.hrl
+++ b/include/pkt_ipv4.hrl
@@ -1,7 +1,9 @@
+-define(IPV4_PROTO_TCP, 6).
+
 -record(ipv4, {
         v = 4 :: pkt:bit4(), hl = 5 :: pkt:bit4(), tos = 0 :: pkt:uint8_t(), len = 20 :: pkt:uint16_t(),
         id = 0 :: pkt:uint16_t(), df = 0 :: pkt:bit(), mf = 0 :: pkt:bit(),
-        off = 0 :: 0 .. 2#1111111111111, ttl = 64 :: pkt:uint8_t(), p = ?IPPROTO_TCP :: pkt:uint8_t(), sum = 0 :: pkt:uint16_t(),
+        off = 0 :: 0 .. 2#1111111111111, ttl = 64 :: pkt:uint8_t(), p = ?IPV4_PROTO_TCP :: pkt:uint8_t(), sum = 0 :: pkt:uint16_t(),
         saddr = {127,0,0,1} :: pkt:in_addr(), daddr = {127,0,0,1} :: pkt:in_addr(),
         opt = <<>> :: binary()
     }).

--- a/include/pkt_ipv6.hrl
+++ b/include/pkt_ipv6.hrl
@@ -1,7 +1,9 @@
+-define(IPV6_PROTO_TCP, 6).
+
 %% RFC 2460: IPv6 Specification
 -record(ipv6, {
         v = 6 :: pkt:bit4(), class = 0 :: pkt:uint8_t(), flow = 0 :: 0 .. 2#11111111111111111111,
-        len = 40 :: pkt:uint16_t(), next = ?IPPROTO_TCP :: pkt:uint8_t(), hop = 0 :: pkt:uint8_t(),
+        len = 40 :: pkt:uint16_t(), next = ?IPV6_PROTO_TCP :: pkt:uint8_t(), hop = 0 :: pkt:uint8_t(),
         saddr :: pkt:in6_addr(), daddr :: pkt:in6_addr()
     }).
 


### PR DESCRIPTION
Because without them we will have problems during using of pkt from
elixir because of fail of elixir's `Record.extract`