### PR TITLE
Issue 47: Adding new API pkt:encode()

### DIFF
--- a/test/pkt_lldp_tests.erl
+++ b/test/pkt_lldp_tests.erl
@@ -6,7 +6,8 @@
 codec_test_() ->
     [
         decode(),
-        encode()
+        encode(),
+        pkt_decode()
     ].
 
 packet() ->
@@ -42,6 +43,13 @@ packet() ->
       16#30, 16#33, 16#2d, 16#30, 16#35, 16#30, 16#35, 16#00,
       16#fe, 16#05, 16#00, 16#80, 16#c2, 16#04, 16#00, 16#00,
       16#00>>.
+packet(entire_pkt) ->
+    <<
+        16#01, 16#80, 16#c2, 16#00, 16#00, 16#0e, 16#00, 16#04, 16#96, 16#1f, 16#a7, 16#26, 16#88, 16#cc, 16#02, 16#07,
+        16#04, 16#00, 16#04, 16#96, 16#1f, 16#a7, 16#26, 16#04, 16#04, 16#05, 16#31, 16#2f, 16#33, 16#06, 16#02, 16#00,
+        16#78, 16#06, 16#02, 16#00, 16#01, 16#06, 16#02, 16#00, 16#02, 16#06, 16#02, 16#00, 16#03, 16#00, 16#00, 16#ff,
+        16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#ff, 16#aa, 16#bb
+    >>.
 
 decode() ->
     ?_assertEqual({{lldp, [{chassis_id,mac_address,<<0,1,48,249,173,160>>},
@@ -67,3 +75,19 @@ decode() ->
 encode() ->
     {Header, _Payload} = pkt:lldp(packet()),
     ?_assertEqual(pkt:lldp(Header), packet()).
+
+pkt_decode() ->
+    ?_assertEqual(
+        {ok,{[{ether,<<1,128,194,0,0,14>>,
+            <<0,4,150,31,167,38>>,
+            35020,0},
+            {lldp,[{chassis_id,mac_address,<<0,4,150,31,167,38>>},
+                {port_id,interface_name,<<"1/3">>},
+                {ttl,120},
+                {ttl,1},
+                {ttl,2},
+                {ttl,3},
+                end_of_lldpdu]}],
+            <<>>}},
+        pkt:codec(packet(entire_pkt))
+    ).

--- a/test/pkt_tests.erl
+++ b/test/pkt_tests.erl
@@ -13,6 +13,8 @@ pkt_test_() ->
         decode_2(),
         decode_2_failure(),
         decode_2_unsupported(),
+        encode_1(),
+        encode_2(),
         makesum_1(),
         makesum_2(),
         makesum_4(),
@@ -29,7 +31,10 @@ packet(ether) ->
       16,22,69,237,136,137,0>>;
 packet(tcp) ->
     <<0,80,217,184,222,13,22,43,241,75,9,12,176,18,17,4,140,86,
-      0,0,2,4,5,172,1, 3,3,0,1,1,8,10,190,15,172,236,0,64,161,73,4,2,0,0>>.
+      0,0,2,4,5,172,1, 3,3,0,1,1,8,10,190,15,172,236,0,64,161,73,4,2,0,0>>;
+packet(ipv4_hdr) ->
+    <<69,0,0,54,2,108,64,0,53,6,172,243,173,192,82,195,192,
+        168,213,54>>.
 
 decapsulate_1() ->
     ?_assertEqual(
@@ -115,6 +120,28 @@ decode_2_unsupported() ->
                                10,190,15,172,236,0,64,161,73,4,2,0,0>>}},
         pkt:decode(ether, packet(tcp))
     ).
+
+encode_1() -> [
+    ?_assertEqual(
+        packet(ether),
+        pkt:encode(pkt:decapsulate(packet(ether)))
+    ),
+    ?_assertNotEqual(
+        packet(ether),
+        pkt:encode({pkt:decapsulate(packet(ether)), <<0,2>>})
+    )
+].
+
+encode_2() -> [
+    ?_assertEqual(
+        packet(ipv4_hdr),
+        pkt:encode(pkt:ipv4(packet(ipv4_hdr)))
+    ),
+    ?_assertNotEqual(
+        packet(ipv4_hdr),
+        pkt:encode({pkt:ipv4(packet(ipv4_hdr)), <<0,1>>})
+    )
+].
 
 makesum_1() ->
     ?_assertEqual(


### PR DESCRIPTION
1. Adding new API pkt:encode/1 to convert pkt data provided as records to binary data
2. A minor enhancement to be able to parse lldp data when given a packet frame which includes ethernet header as well. Checkout eunit case: pkt_lldp_tests:pkt_decode/0