### PR TITLE
handle chunks that are too short

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _build
 *.swp
+/ebin/
+/.rebar3/


### PR DESCRIPTION
when `decode_chunks` is called with a binary that's longer than 4 bytes, but shorter than `Length`, the match on line 58 will fail.

can happen e.g. in truncated files.
