### PR TITLE
LINKTYPE_LINUX_SLL2 - linux cooked v2

### DIFF
--- a/include/pkt_dlt.hrl
+++ b/include/pkt_dlt.hrl
@@ -25,3 +25,4 @@
 -define(DLT_IEEE802_11_RADIO, 127).
 -define(DLT_APPLE_IP_OVER_IEEE1394, 138).
 -define(DLT_IEEE802_11_RADIO_AVS, 163).
+-define(DLT_LINUX_SLL2, 276).                % Linux cooked v2 sockets fake hdr

--- a/include/pkt_linux_cooked.hrl
+++ b/include/pkt_linux_cooked.hrl
@@ -5,3 +5,13 @@
         ll_bytes = <<0,0,0,0,0,0,0,0>> :: <<_:64>>,
         pro = ?ETH_P_IP :: pkt:uint16_t()
     }).
+
+-record(linux_cooked_v2, {
+         pro = ?ETH_P_IP :: pkt:uint16_t(),
+         mbz = <<0,0>> :: <<_:16>>,
+         if_idx = 1 :: pkt:uint32_t(),
+         hrd = ?ARPHRD_ETHER :: pkt:uint16_t(),
+         packet_type = ?DLT_LINUX_SLL2 :: pkt:uint16_t(),
+         ll_len = 0 :: pkt:uint16_t(),
+         ll_bytes = <<0,0,0,0,0,0,0,0>> :: <<_:64>>
+    }).

--- a/src/pkt.erl
+++ b/src/pkt.erl
@@ -51,6 +51,7 @@
         null/1,
         gre/1,
         linux_cooked/1,
+        linux_cooked_v2/1,
         icmp/1,
         icmp6/1,
         igmp/1,
@@ -110,6 +111,8 @@ decapsulate_next({en10mb, Data}, Headers) ->
     decapsulate_next({ether, Data}, Headers);
 decapsulate_next({linux_sll, Data}, Headers) ->
     decapsulate_next({linux_cooked, Data}, Headers);
+decapsulate_next({linux_sll2, Data}, Headers) ->
+    decapsulate_next({linux_cooked_v2, Data}, Headers);
 
 % Protocol header indicates next header
 decapsulate_next({null, Data}, Headers) ->
@@ -117,6 +120,9 @@ decapsulate_next({null, Data}, Headers) ->
     decapsulate_next({next(Header), Payload}, [Header|Headers]);
 decapsulate_next({linux_cooked, Data}, Headers) ->
     {Header, Payload} = linux_cooked(Data),
+    decapsulate_next({next(Header), Payload}, [Header|Headers]);
+decapsulate_next({linux_cooked_v2, Data}, Headers) ->
+    {Header, Payload} = linux_cooked_v2(Data),
     decapsulate_next({next(Header), Payload}, [Header|Headers]);
 decapsulate_next({ether, Data}, Headers) ->
     {Header, Payload} = ether(Data),
@@ -242,6 +248,8 @@ decode_next({en10mb, Data}, Headers) ->
     decode_next({ether, Data}, Headers);
 decode_next({linux_sll, Data}, Headers) ->
     decode_next({linux_cooked, Data}, Headers);
+decode_next({linux_sll2, Data}, Headers) ->
+    decode_next({linux_cooked_v2, Data}, Headers);
 
 % Protocol header indicates next header
 decode_next({Proto, Data}, Headers) when
@@ -250,6 +258,7 @@ decode_next({Proto, Data}, Headers) when
     Proto =:= ipv4;
     Proto =:= ipv6;
     Proto =:= linux_cooked;
+    Proto =:= linux_cooked_v2;
     Proto =:= null;
     Proto =:= '802.1q';
 
@@ -311,6 +320,7 @@ decode_next({Proto, Data}, Headers) when
 
 next(#null{family = Family}) -> family(Family);
 next(#linux_cooked{pro = Pro}) -> ether_type(Pro);
+next(#linux_cooked_v2{pro = Pro}) -> ether_type(Pro);
 next(#ether{type = Type}) -> ether_type(Type);
 next(#'802.1q'{type = Type}) -> ether_type(Type);
 next(#ipv4{off = Off}) when Off =/= 0 -> '$stop';
@@ -332,6 +342,8 @@ null(N) ->
 %% Linux cooked capture ("-i any") - DLT_LINUX_SLL
 linux_cooked(N) ->
     pkt_linux_cooked:codec(N).
+linux_cooked_v2(N) ->
+    pkt_linux_cooked_v2:codec(N).
 
 %% Ethernet
 ether(N) ->

--- a/src/pkt_dlt.erl
+++ b/src/pkt_dlt.erl
@@ -64,6 +64,7 @@ codec(?DLT_PFLOG) -> pflog;
 codec(?DLT_IEEE802_11_RADIO) -> ieee802_11_radio;
 codec(?DLT_APPLE_IP_OVER_IEEE1394) -> apple_ip_over_ieee1394;
 codec(?DLT_IEEE802_11_RADIO_AVS) -> ieee802_11_radio_avs;
+codec(?DLT_LINUX_SLL2) -> linux_sll2;
 
 codec(null) -> ?DLT_NULL;
 codec(en10mb) -> ?DLT_EN10MB;
@@ -91,4 +92,5 @@ codec(linux_sll) -> ?DLT_LINUX_SLL;
 codec(pflog) -> ?DLT_PFLOG;
 codec(ieee802_11_radio) -> ?DLT_IEEE802_11_RADIO;
 codec(apple_ip_over_ieee1394) -> ?DLT_APPLE_IP_OVER_IEEE1394;
-codec(ieee802_22_radio_avs) -> ?DLT_IEEE802_11_RADIO_AVS.
+codec(ieee802_22_radio_avs) -> ?DLT_IEEE802_11_RADIO_AVS;
+codec(linux_sll2) -> ?DLT_LINUX_SLL2.

--- a/src/pkt_linux_cooked_v2.erl
+++ b/src/pkt_linux_cooked_v2.erl
@@ -1,0 +1,53 @@
+%% Copyright (c) 2009-2022, Michael Santos <michael.santos@gmail.com>
+%% All rights reserved.
+%%
+%% Redistribution and use in source and binary forms, with or without
+%% modification, are permitted provided that the following conditions
+%% are met:
+%%
+%% Redistributions of source code must retain the above copyright
+%% notice, this list of conditions and the following disclaimer.
+%%
+%% Redistributions in binary form must reproduce the above copyright
+%% notice, this list of conditions and the following disclaimer in the
+%% documentation and/or other materials provided with the distribution.
+%%
+%% Neither the name of the author nor the names of its contributors
+%% may be used to endorse or promote products derived from this software
+%% without specific prior written permission.
+%%
+%% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+%% "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+%% LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+%% FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+%% COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+%% INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+%% BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+%% LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+%% CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+%% LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+%% ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+%% POSSIBILITY OF SUCH DAMAGE.
+-module(pkt_linux_cooked_v2).
+
+-include("pkt_dlt.hrl").
+-include("pkt_ether.hrl").
+-include("pkt_arp.hrl").
+-include("pkt_linux_cooked.hrl").
+
+-export([codec/1]).
+
+codec(<<Pro:16/big, MBZ:2/bytes, Ifi:32/big, Hrd:16/big,
+        Ptype:8, Ll_len:8/big, Ll_hdr:8/bytes, Payload/binary>>) ->
+    {#linux_cooked_v2{
+        pro = Pro, mbz = MBZ, if_idx = Ifi,
+        hrd = Hrd, packet_type = Ptype,
+        ll_len = Ll_len, ll_bytes = Ll_hdr
+       }, Payload};
+codec(#linux_cooked_v2{
+         pro = Pro, mbz = MBZ, if_idx = Ifi,
+         hrd = Hrd, packet_type = Ptype,
+         ll_len = Ll_len, ll_bytes = Ll_hdr
+        }) ->
+    <<Pro:16/big, MBZ:2/bytes, Ifi:32/big, Hrd:16/big,
+      Ptype:16, Ll_len:8/big, Ll_hdr:8/bytes>>.


### PR DESCRIPTION
Support for LINKTYPE_LINUX_SLL2